### PR TITLE
Delimiter args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 bin/
+.vscode

--- a/include/impl.hh
+++ b/include/impl.hh
@@ -25,6 +25,9 @@ std::string strToLowerCase(std::string line);
 // for testing: get the current state of the classifier
 std::string _get_current();
 
+//checks if a character is a metacharacter
+bool checkMetacharacter(std::string inputString, size_t position);
+
 //cd commands builtin
 
 //int builtin_cd

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -122,10 +122,10 @@ std::string process()
     if (res != ""){
         args.emplace_back(tempArg);
     }
-
+    /* Debug code to print out arguments. Can be removed without issue.
     for (size_t i = 0; i < args.size(); i++){
         std::cout << "ARG[" << i << "]: " << args[i] << std::endl;;
-    }
+    }*/
 
     //if the map returns a key
     if (dict.count(res)) {

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -266,7 +266,7 @@ bool checkMetacharacter(std::string inputString, size_t position){
         return false; //Not a metacharacter as it is quoted.
     }
     //Check if metacharacter
-    std::string metaCharacters = "|&;()<> ";
+    std::string metaCharacters = "|&;()<> \\";
     char indivChar = inputString[position];
     for (size_t i = 0; i < metaCharacters.length(); i++){
         if (indivChar == metaCharacters[i]){

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -102,14 +102,30 @@ std::unordered_map<std::string, std::string> dict =
 // 'line' should be the parsed line from 'parse()'
 std::string process()
 {
-    // todo: process parsed line
     std::string res;
+    std::vector<std::string> args;
 
     //get parsed line
     res = current_line;
 
-    //split the current line by ' ' and set res to first word
-    res = res.substr(0, res.find(' '));
+    //Go through every character in the line, split them into args
+    std::string tempArg;
+    for(size_t i=0; i < res.length(); i++){
+        if (res[i] != ' '){ //If the current space isn't blank, add to tempArg
+            tempArg = tempArg + res[i];
+        }else{ //We hit a blank space, so we split the line. Add current arg to args, reset temp arg.
+            args.emplace_back(tempArg);
+            tempArg = "";
+        }
+    }
+    //The above loop only adds an argument if there is a space, so we need this to get the inital arg.
+    if (res.length() != 0){
+        args.emplace_back(tempArg);
+    }
+
+    for (size_t i = 0; i < args.size(); i++){
+        std::cout << "ARG[" << i << "]: " << args[i] << std::endl;;
+    }
 
     //if the map returns a key
     if (dict.count(res)) {

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -119,7 +119,7 @@ std::string process()
         }
     }
     //The above loop only adds an argument if there is a space, so we need this to get the inital arg.
-    if (res.length() != 0){
+    if (res != ""){
         args.emplace_back(tempArg);
     }
 

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -161,25 +161,6 @@ std::string parse(std::string line)
         return PROMPT_NEW;
     }
 
-    // Dylan: Remove extra whitespace from the line.
-    std::string tempLine;
-    bool encounteredFirstChar = false;
-    for (size_t i = 0; i < line.length(); i++){
-        if (line[i] == ' ' || line[i] == '\t'){ //Check and see if we have found a space or tab.
-            //First check to make sure we are not at the end of the line and we have had a character
-            if (i+1 < line.length() && encounteredFirstChar){
-                //If the next character is not a space/tab, we can add a space.
-                if (line[i+1] != ' ' && line[i+1] != '\t'){
-                    tempLine += ' ';
-                }
-            }
-        }else{ //The character was not a space or tab, so just add it
-            tempLine += line[i];
-            encounteredFirstChar = true;
-        }
-    }
-    line = tempLine;
-
     // to store the comment start location
     size_t comment_start = std::string::npos;
     // for char in line, search for a comment start location
@@ -214,6 +195,24 @@ std::string parse(std::string line)
             line = line.substr(0, comment_start);
         }
     }
+    // Dylan: Remove extra whitespace from the line.
+    std::string tempLine;
+    bool encounteredFirstChar = false;
+    for (size_t i = 0; i < line.length(); i++){
+        if (line[i] == ' ' || line[i] == '\t'){ //Check and see if we have found a space or tab.
+            //First check to make sure we are not at the end of the line and we have had a character
+            if (i+1 < line.length() && encounteredFirstChar){
+                //If the next character is not a space/tab, we can add a space.
+                if (line[i+1] != ' ' && line[i+1] != '\t'){
+                    tempLine += ' ';
+                }
+            }
+        }else{ //The character was not a space or tab, so just add it
+            tempLine += line[i];
+            encounteredFirstChar = true;
+        }
+    }
+    line = tempLine;
 
     // if there's a continuation
     if ( line != "" && line[line.length() - 1] == '\\')

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -111,9 +111,9 @@ std::string process()
     //Go through every character in the line, split them into args
     std::string tempArg;
     for(size_t i=0; i < res.length(); i++){
-        if (res[i] != ' '){ //If the current space isn't blank, add to tempArg
+        if (!checkMetacharacter(res, i)){ //If not a meta character, add to tempArg
             tempArg = tempArg + res[i];
-        }else{ //We hit a blank space, so we split the line. Add current arg to args, reset temp arg.
+        }else{ //We hit a meta character, so we split the line. Add current arg to args, reset temp arg.
             args.emplace_back(tempArg);
             tempArg = "";
         }
@@ -122,10 +122,10 @@ std::string process()
     if (res != ""){
         args.emplace_back(tempArg);
     }
-    /* Debug code to print out arguments. Can be removed without issue.
+    /* Debug code to print out arguments. Can be removed without issue.*/
     for (size_t i = 0; i < args.size(); i++){
         std::cout << "ARG[" << i << "]: " << args[i] << std::endl;;
-    }*/
+    }
 
     //if the map returns a key
     if (dict.count(res)) {
@@ -246,6 +246,35 @@ std::string strToLowerCase(std::string line) {
   return line;
 
 }//end strToLowerCase
+
+//Check if there is a meta character in the given string at the given position.
+bool checkMetacharacter(std::string inputString, size_t position){
+    //Check if quoted
+    bool quoteLeft = false;
+    bool quoteRight = false;
+    //Make sure position is not at end or start of line.
+    if (position > 0 && position < (inputString.length()-1)){
+        //Check to see if there is a quote left or right of current char.
+        if(inputString[position-1] == '"'){
+            quoteLeft = true;
+        }
+        if(inputString[position+1] == '"'){
+            quoteRight = true;
+        }
+    }
+    if(quoteLeft && quoteRight){
+        return false; //Not a metacharacter as it is quoted.
+    }
+    //Check if metacharacter
+    std::string metaCharacters = "|&;()<> ";
+    char indivChar = inputString[position];
+    for (size_t i = 0; i < metaCharacters.length(); i++){
+        if (indivChar == metaCharacters[i]){
+            return true; //meta char found
+        }
+    }
+    return false; //did not find a meta char
+}
 
 // commented in header
 std::string _get_current()

--- a/src/main.cc
+++ b/src/main.cc
@@ -18,6 +18,9 @@ int main()
 	    line = strToLowerCase(line);
 
         // if exit, exit
+        /* TODO: This probably needs to be implemented as it's own internal command
+            At least that is how professor Kim had it.
+        */
         if (line == "exit")
         {
             break;


### PR DESCRIPTION
This branch adds support for detecting meta characters and then splitting a line into arguments using said meta characters.

There is also some debug code still active. It prints out the arguments individually. Let me know to remove them or just remove them yourself if needed.

Also relocated code that checks for duplicate whitespace after the comment checker. I think the comment checker might generate extra whitespace? Whatever the case, having the whitespace check after the comment stuff fixes it.