### PR TITLE
36 implement commands actually running

### DIFF
--- a/src/impl.cc
+++ b/src/impl.cc
@@ -109,7 +109,7 @@ std::string process()
     argv.reserve(args.size());
 
     /* Debug code to print out arguments. Can be removed without issue.*/
-    for (size_t i = 1; i <= args.size(); i++)
+    for (size_t i = 0; i < args.size(); i++)
     {
         std::cout << "ARG[" << i << "]: " << args[i] << std::endl;
         ;
@@ -124,9 +124,14 @@ std::string process()
 
         // get class from dictionary
         std::string lineClassName = dict.at(res).keyword;
-        std::cout << "HERE" << std::endl;
-        dict.at(res).function_pointer(args.size(), argv.data());
-
+        if(dict.at(res).function_pointer != nullptr)
+        {
+            dict.at(res).function_pointer(args.size(), argv.data());
+        } 
+        else 
+        {
+            std::cout << "NOT YET IMPLEMENTED" << std::endl;
+        }
 
         // append class to line
         res = res + " " + lineClassName;

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -314,6 +314,7 @@ int builtin_cd(int argc, char ** argv)
     }
 
     // if argument is -{n}, convert to string to select from table
+    // note: this works primarily because of short circuit evaluation
     if (argc >=2 && isdigit(argv[1][1]))
     {
         key = "-{n}";

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -49,7 +49,7 @@ std::unordered_map<std::string, DictStruct> dict =
     {"while", {KEYWORD, nullptr}},
     {"alias", {INTERNAL, nullptr}},
     {"bg", {INTERNAL, nullptr}},
-    {"cd", {INTERNAL, *builtin_cd}},
+    {"cd", {INTERNAL, builtin_cd}},
     {"eval", {INTERNAL, nullptr}},
     {"exec", {INTERNAL, nullptr}},
     {"exit", {INTERNAL, nullptr}},
@@ -78,6 +78,8 @@ std::string process()
 {
     std::string res;
     std::vector<std::string> args;
+    std::vector<std::vector<char>> holder;
+    std::vector<char*> argv;
 
     // get parsed line
     res = current_line;
@@ -101,11 +103,19 @@ std::string process()
     {
         args.emplace_back(tempArg);
     }
+
+    // resize holder and argv to the args size
+    holder.reserve(args.size());
+    argv.reserve(args.size());
+
     /* Debug code to print out arguments. Can be removed without issue.*/
-    for (size_t i = 0; i < args.size(); i++)
+    for (size_t i = 1; i <= args.size(); i++)
     {
         std::cout << "ARG[" << i << "]: " << args[i] << std::endl;
         ;
+        holder.emplace_back(args[i].begin(), args[i].end());
+        holder.back().push_back('\0');
+        argv.push_back(holder.back().data());
     }
 
     // if the map returns a key
@@ -114,6 +124,9 @@ std::string process()
 
         // get class from dictionary
         std::string lineClassName = dict.at(res).keyword;
+        std::cout << "HERE" << std::endl;
+        dict.at(res).function_pointer(args.size(), argv.data());
+
 
         // append class to line
         res = res + " " + lineClassName;

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -314,7 +314,7 @@ int builtin_cd(int argc, char ** argv)
     }
 
     // if argument is -{n}, convert to string to select from table
-    if (isdigit(argv[1][1]))
+    if (argc >=2 && isdigit(argv[1][1]))
     {
         key = "-{n}";
     }


### PR DESCRIPTION
CD runs properly now.  Please note that in builin_cd, it would crash without any flags since it would try to look in a spot that didn't exist.  Since c++ uses shortcircuit evaluation, that section will never be ran if there are less than 2 args passed.  We also used vectors to translate everything into char**.