### PR TITLE
Implement batch mode as argument and script indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ this is the example command
 
 ### Batch Mode
 
-you would do one of the following
+To run a script in batch mode, there are 3 possible options.
 
 #### Executable Script
-Add `#!./bin/main` to the head of a file and make it executable
+- Give the script a path to CRASH by including `#!PATHTOCRASH` in the first line of the file. If in the test directory for example, use `#!./bin/main`.
+- Make sure the file is executable by running `chmod +x FILENAME`
+- Execute the script by running in a terminal `./SCRIPTNAME.EXTENSION`
 
 #### Stdin Piping
 Create a script and run `./bin/main < [script location]`

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ To run a script in batch mode, there are 3 possible options.
 - Make sure the file is executable by running `chmod +x FILENAME`
 - Execute the script by running in a terminal `./SCRIPTNAME.EXTENSION`
 
-#### Stdin Piping
-Create a script and run `./bin/main < [script location]`
+#### Script as argument.
+- Navigate to the directory that contains the script
+- Enter the name of the script into crash `testScript` or `script.txt`. Extension doesn't matter.
 
-#### Script by Name
-Create a script and run `./bin/main [script location]`
+#### Script indirection
+Create a script and run `./bin/main < [script location]`

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ To run a script in batch mode, there are 3 possible options.
 #### Script as argument.
 - Navigate to the directory that contains the script
 - Enter the name of the script into crash `testScript` or `script.txt`. Extension doesn't matter.
+- These actions be combined as one by specifying the path to the script and its name.
+    - For example, if in CRASH's root directory, `test/testScript` to run testScript
 
 #### Script indirection
-Create a script and run `./bin/main < [script location]`
+- Follow the same steps as [script as argument](#Script-as-argument), but include a `<` before entering the name of the script or path.

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -164,17 +164,18 @@ std::string process()
             getcwd(cwd, sizeof(cwd));
             std::string localPath = cwd + '/' + args[0];
             struct stat localFile;
-            //If our current argument and path is a valid script
+            //If our current argument and path is a valid file
             if (stat(localPath.c_str(), &localFile) == 0 && (localFile.st_mode & S_IFMT) == S_IFREG){
                 std::ifstream localFileContent;
-                localFileContent.open(args[0]);
+                localFileContent.open(args[0]); //Open the file in current directory that has the name of first argument
                 std::vector<std::string> localLines;
                 std::string line;
-                // read all lines to 'lines'
+                //Store all lines of the file to localLines
                 while (getline(localFileContent, line)){
                     localLines.push_back(line);
                 }
                 localFileContent.close();
+                //Parse all lines of the file
                 for (size_t i = 0; i < localLines.size(); i++){
                     parse(localLines[i]);
                 }

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -101,7 +101,7 @@ std::string process()
     res = current_line;
 
     // Go through every character in the line, split them into args
-    std::string tempArg;
+    std::string tempArg; //To store arguments, before they are split
     for (size_t i = 0; i < res.length(); i++)
     {
         if (!checkMetacharacter(res, i))
@@ -109,9 +109,11 @@ std::string process()
             tempArg = tempArg + res[i];
         }
         else
-        { // We hit a meta character, so we split the line. Add current arg to args, reset temp arg.
-            args.emplace_back(tempArg);
-            tempArg = "";
+        { // We hit a meta character, so we split the line. Add current arg (if not empty) to args, reset temp arg.
+            if(!tempArg.empty()){
+                args.emplace_back(tempArg);
+            }
+            tempArg.clear();
         }
     }
     // The above loop only adds an argument if there is a space, so we need this to get the inital arg.

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -160,6 +160,24 @@ std::string process()
             std::string env_s = std::string(env_p);
             char cwd[PATH_MAX];
             getcwd(cwd, sizeof(cwd));
+            std::string localPath = cwd + '/' + args[0];
+            struct stat localFile;
+            //If our current argument and path is a valid script
+            if (stat(localPath.c_str(), &localFile) == 0 && (localFile.st_mode & S_IFMT) == S_IFREG){
+                std::ifstream localFileContent;
+                localFileContent.open(args[0]);
+                std::vector<std::string> localLines;
+                std::string line;
+                // read all lines to 'lines'
+                while (getline(localFileContent, line)){
+                    localLines.push_back(line);
+                }
+                localFileContent.close();
+                for (size_t i = 0; i < localLines.size(); i++){
+                    parse(localLines[i]);
+                }
+            }
+            
             std::stringstream stream(env_s + ":" + cwd);
             std::string segment;
             bool found = false;
@@ -230,6 +248,8 @@ std::string process()
 // commented in header
 std::string parse(std::string line)
 {
+    //Clear the current line before parsing
+    current_line.clear();
     // if there's a blank line
     if (line.length() == 0)
     {
@@ -362,7 +382,7 @@ std::string getNewPrompt()
 }
 
 // commented in header
-std::string _get_current()
+std::string _get_current() //TODO: Do we need this? Does it do anything?
 {
     return current_line;
 }

--- a/src/impl.cc
+++ b/src/impl.cc
@@ -170,14 +170,18 @@ std::string process()
                 localFileContent.open(args[0]); //Open the file in current directory that has the name of first argument
                 std::vector<std::string> localLines;
                 std::string line;
-                //Store all lines of the file to localLines
-                while (getline(localFileContent, line)){
-                    localLines.push_back(line);
-                }
-                localFileContent.close();
-                //Parse all lines of the file
-                for (size_t i = 0; i < localLines.size(); i++){
-                    parse(localLines[i]);
+                if (localFileContent.is_open()){
+                    //Store all lines of the file to localLines
+                    while (getline(localFileContent, line)){
+                        localLines.push_back(line);
+                    }
+                    localFileContent.close();
+                    //Parse all lines of the file
+                    for (size_t i = 0; i < localLines.size(); i++){
+                        parse(localLines[i]);
+                    }
+                }else{
+                    std::cout << "Error encountered while trying to open: " << args[0] << std::endl;
                 }
             }
             

--- a/test/testScript
+++ b/test/testScript
@@ -1,3 +1,2 @@
-dig
-lsblk
-lsusb
+cd -H
+cd -H

--- a/test/testScript
+++ b/test/testScript
@@ -1,0 +1,3 @@
+dig
+lsblk
+lsusb


### PR DESCRIPTION
Got running script files from inside CRASH working. 

We check the local path + argument for the script location separate from where we check the PATH environment, as we do not want to try and parse every file the PATH environment would return. That would _probably_ be bad.

If we find a valid file using our local path + argument, we open the file, store it, and then parse it.

Also had to solve a bug of the current line not getting cleared before we parse.

Only issue is I'm not sure if the indirection is correct. It works but it is functionally the same as how we process running an argument inside of CRASH. See https://github.com/Eagle-9/crash/issues/57#issuecomment-1958761894 for more details.
