### PR TITLE
Fix run command

### DIFF
--- a/src/shell.cc
+++ b/src/shell.cc
@@ -322,7 +322,7 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
             print_prompt();
             return;
         }
-        argv.erase(argv.begin());
+        //argv.erase(argv.begin()); This is bad!
 
         // create a child process
         pid_t child = fork();
@@ -355,6 +355,7 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
 
             // switch execution to new binary
 
+            argv.emplace_back(nullptr); //You might want this in a different spot? Maybe in argv_from_tokens? Idk?
             execv(full_path.c_str(), argv.data());
 
             std::cerr << "[!!] What are we doing here?!\n";


### PR DESCRIPTION
This might solve #97, need @dennorak to confirm if this was the issue.

Issue 1:Argv needs to be terminated by a null pointer

Issue 2: Do not delete the first argument of argv
     - If you do, `echo hello world test` instead returns `world test`

Source: https://linux.die.net/man/3/execv
_"The first argument, by convention, should point to the filename associated with the file being executed. The list of arguments must be terminated by a NULL pointer"_
