### PR TITLE
117 add color output for crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ To run a script in batch mode, there are 3 possible options.
 | 2>>    | Append Error         |
 
 ### Meta Character Usage
-- `\`
-- `#`
+- `\` Use backslack to continue a line
+- `#` Use hashtags to add comments
 - `;` Use semicolons to seperate lines to run multiple commands at once.
   - To run both the external `lsblk` and `lscpu` commands.
   - `CRASH $ lsblk ; lscpu`
@@ -83,6 +83,12 @@ To run a script in batch mode, there are 3 possible options.
 - `>>` Use two greater than character to append the output from a command to a file.
   - To append the output of `lsblk` to a file called `output.txt` that already has existing content.
   - `CRASH $ lsblk >> output.txt`
+- `|` Use a vertical bar to pipe the output of one program to another.
+  - To pipe the output of `lscpu` to `sort` to have the output in alphabetical order.
+  - `CRASH $ lscpu | sort`
+- `<` Use a less than character to redirect the input of  program to a file.
+  - To display the contents of a file called `test5.txt`
+  - `CRASH $ cat < test5.txt`
 
 ### Wild Card Character Matching
 

--- a/include/crash.hh
+++ b/include/crash.hh
@@ -32,6 +32,9 @@
 #define MAGENTA "\033[35m"      /* Magenta */
 #define CYAN    "\033[36m"      /* Cyan */
 #define WHITE   "\033[37m"      /* White */
+#define PRINT_ERROR RED << "[ERROR]" << RESET
+#define PRINT_WARN YELLOW << "[WARN]" << RESET
+#define PRINT_DEBUG CYAN << "[DEBUG]" << RESET
 
 const std::string PROMPT_NEW = "$ ";
 const std::string PROMPT_CNT = ">>> ";

--- a/include/crash.hh
+++ b/include/crash.hh
@@ -22,6 +22,17 @@
 #define HOME getenv("HOME")
 #define HISTORY_FILE_PATH (std::string(HOME) + "/crash_history.txt").c_str()
 
+//Colors
+#define RESET   "\033[0m"
+#define BLACK   "\033[30m"      /* Black */
+#define RED     "\033[31m"      /* Red */
+#define GREEN   "\033[32m"      /* Green */
+#define YELLOW  "\033[33m"      /* Yellow */
+#define BLUE    "\033[34m"      /* Blue */
+#define MAGENTA "\033[35m"      /* Magenta */
+#define CYAN    "\033[36m"      /* Cyan */
+#define WHITE   "\033[37m"      /* White */
+
 const std::string PROMPT_NEW = "$ ";
 const std::string PROMPT_CNT = ">>> ";
 #define PATH_MAX 1024

--- a/src/builtin/alias.cc
+++ b/src/builtin/alias.cc
@@ -1,4 +1,5 @@
 #include <crash.hh>
+#define PRINT_ALIAS GREEN << "[ALIAS]" << RESET
 
 int alias_help(int argc, char **argv)
 {
@@ -19,7 +20,7 @@ int alias_help(int argc, char **argv)
     }
     else
     {
-        std::cout << "[ALIAS][ERROR]: Not a known command. Did you mean alias -h or alias -H ?" << std::endl; // not a known command
+        std::cerr << PRINT_ALIAS << PRINT_ERROR << ": Not a known command. Did you mean alias -h or alias -H ?" << std::endl; // not a known command
         return 1;
     }
     return 0;
@@ -30,7 +31,7 @@ void alias_print(void)
     // print out each alias
     for (auto iter = aliases.begin(); iter != aliases.end(); iter++)
     {
-        std::cout << "[ALIAS]: " << iter->first << "='" << iter->second << "'" << std::endl;
+        std::cout << PRINT_ALIAS <<": " << iter->first << "='" << iter->second << "'" << std::endl;
     }
 }
 
@@ -42,7 +43,7 @@ int alias_parse(std::string line)
     // check for invalid string
     if (find == std::string::npos)
     {
-        std::cout << "[ALIAS][ERROR]: INVALID ALIAS" << std::endl;
+        std::cerr << PRINT_ALIAS << PRINT_ERROR << ": INVALID ALIAS" << std::endl;
         return 1;
     }
 
@@ -74,7 +75,7 @@ int alias_parse(std::string line)
     // if it exists, return an error
     if (aliases.count(name))
     {
-        std::cout << "[ALIAS][ERROR]: Alias name already exists. Please use unalias to remove it before making a new one" << std::endl;
+        std::cerr << PRINT_ALIAS << PRINT_ERROR << ": Alias name already exists. Please use unalias to remove it before making a new one" << std::endl;
 
         return 1;
     }

--- a/src/builtin/cd.cc
+++ b/src/builtin/cd.cc
@@ -1,5 +1,6 @@
 #include <crash.hh>
 #define CD_HISTORY_FILE_PATH (std::string(HOME) + "/cd_history.txt").c_str()
+#define PRINT_CD GREEN << "[CD]" << RESET
 
 int cd_help_message(int argc, char **argv)
 {
@@ -21,7 +22,7 @@ int cd_help_message(int argc, char **argv)
     }
     else
     {
-        std::cout << "[CD][ERROR]: Not a known command. Did you mean cd -h or cd -H ?" << std::endl; // not a known command
+        std::cerr << PRINT_CD << PRINT_ERROR << ": Not a known command. Did you mean cd -h or cd -H ?" << std::endl; // not a known command
         return 1;
     }
     return 0;
@@ -34,12 +35,12 @@ void cd_create_history_file()
     writeFile.open(CD_HISTORY_FILE_PATH);
     if (writeFile.fail())
     {
-        std::cout << "[CD][ERROR]: Failed to create history file" << std::endl;
+        std::cerr << PRINT_CD << PRINT_ERROR << ": Failed to create history file" << std::endl;
     }
     writeFile.close();
 
     if(crash_debug)
-        std::cout << "[CD][DEBUG]: Created cd history file" << std::endl;
+        std::cout << PRINT_CD << PRINT_DEBUG << ": Created cd history file" << std::endl;
 }
 
 int cd_history_length()
@@ -180,7 +181,7 @@ int cd_nth_history(int argc, char **argv)
         // if the chdir failed, report error. otherwise, log the cwd
         if (chdir(dir.c_str()) != 0)
         {
-            std::cout << "[CD][ERROR]: Failed to change directory: " << dir << std::endl;
+            std::cerr << PRINT_CD << PRINT_ERROR << ": Failed to change directory: " << dir << std::endl;
         }
         else
         {
@@ -192,7 +193,7 @@ int cd_nth_history(int argc, char **argv)
     }
     else
     {
-        std::cout << "[CD][ERROR]: INVALID NUMBER" << std::endl;
+        std::cerr << PRINT_CD << PRINT_ERROR << ": INVALID NUMBER" << std::endl;
         return 1;
     }
     return 0;
@@ -280,7 +281,7 @@ int builtin_cd(int argc, char **argv)
     {
         if (chdir(key.c_str()) != 0)
         {
-            std::cout << "[CD][ERROR]: Invalid Directory: " << key << "\n";
+            std::cerr << PRINT_CD << PRINT_ERROR << ": Invalid Directory: " << key << "\n";
             return 1;
         }
         else
@@ -293,7 +294,7 @@ int builtin_cd(int argc, char **argv)
     else
     {
         // not in table
-        std::cout << "[CD][ERROR]: The flag " << key << " is not an argument of cd" << std::endl;
+        std::cerr << PRINT_CD << PRINT_ERROR << ": The flag " << key << " is not an argument of cd" << std::endl;
         return 1;
     }
 

--- a/src/builtin/exit.cc
+++ b/src/builtin/exit.cc
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <crash.hh>
+#define PRINT_EXIT GREEN << "[EXIT]" << RESET
 
 int builtin_exit(int argc, char **argv)
 {
@@ -17,6 +18,6 @@ int builtin_exit(int argc, char **argv)
         }
     }
     if(crash_debug)
-        std::cout << "[EXIT][DEBUG]: EXIT" << std::endl;
+        std::cout << PRINT_EXIT << PRINT_DEBUG << ": EXIT" << std::endl;
     exit(0);
 }

--- a/src/builtin/help.cc
+++ b/src/builtin/help.cc
@@ -1,4 +1,5 @@
 #include <crash.hh>
+#define PRINT_HELP GREEN << "[HELP]" << RESET
 
 int help_help(int argc, char **argv)
 {
@@ -19,7 +20,7 @@ int help_help(int argc, char **argv)
     }
     else
     {
-        std::cout << "[HELP][ERROR]: Not a known flag. Did you mean help -h or help -H ?" << std::endl; // not a known command
+        std::cerr << PRINT_HELP << PRINT_ERROR << ": Not a known flag. Did you mean help -h or help -H ?" << std::endl; // not a known command
         return 1;
     }
     return 0;
@@ -70,7 +71,7 @@ int builtin_help(int argc, char **argv)
         }
         else
         {
-            std::cout << "[HELP][ERROR]: " << argv[1] << " is not a valid flag" << std::endl;
+            std::cerr << PRINT_HELP << PRINT_ERROR << ": " << argv[1] << " is not a valid flag" << std::endl;
             return 1;
         }
     }

--- a/src/builtin/history.cc
+++ b/src/builtin/history.cc
@@ -1,4 +1,5 @@
 #include <crash.hh>
+#define PRINT_HISTORY GREEN << "[HISTORY]" << RESET
 
 int history_help_message(int argc, char **argv)
 {
@@ -20,7 +21,7 @@ int history_help_message(int argc, char **argv)
     }
     else
     {
-        std::cout << "[HISTORY][ERROR]: Not a known command. Did you mean history -h or cd -H ?" << std::endl; // not a known command
+        std::cerr << PRINT_HISTORY << PRINT_ERROR << ": Not a known command. Did you mean history -h or cd -H ?" << std::endl; // not a known command
         return 1;
     }
     return 0;
@@ -127,7 +128,7 @@ int history_nth_history(int argc, char **argv)
     }
     else
     {
-        std::cout << "[HISTORY][ERROR]: INVALID NUMBER" << std::endl;
+        std::cout << PRINT_HISTORY << PRINT_ERROR << ": INVALID NUMBER" << std::endl;
         return 1;
     }
     return 0;
@@ -226,12 +227,12 @@ void history_create_history_file()
     writeFile.open(HISTORY_FILE_PATH);
     if (writeFile.fail())
     {
-        std::cout << "[HISTORY][ERROR]: Failed to create history file" << std::endl;
+        std::cerr << PRINT_HISTORY << PRINT_ERROR << ": Failed to create history file" << std::endl;
     }
     writeFile.close();
 
     if(crash_debug)
-        std::cout << "[HISTORY][DEBUG]: Created CRASH history file" << std::endl;
+        std::cout << PRINT_HISTORY << PRINT_DEBUG << ": Created CRASH history file" << std::endl;
 }
 
 void history_write_history_file(const std::string dir)

--- a/src/builtin/set.cc
+++ b/src/builtin/set.cc
@@ -1,4 +1,5 @@
 #include <crash.hh>
+#define PRINT_SET GREEN << "[SET]" << RESET
 
 int set_help(int argc, char **argv)
 {
@@ -31,7 +32,7 @@ int set_help(int argc, char **argv)
     }
     else
     {
-        std::cout << "[SET][ERROR]: Not a known command. Did you mean history -h or cd -H ?" << std::endl; // not a known command
+        std::cerr << PRINT_SET << PRINT_ERROR << ": Not a known command. Did you mean history -h or cd -H ?" << std::endl; // not a known command
         return 1;
     }
     return 0;
@@ -45,7 +46,7 @@ int set_parse(std::string line)
     // check for invalid string
     if (find == std::string::npos)
     {
-        std::cout << "[SET][ERROR]: INVALID SET" << std::endl;
+        std::cerr << PRINT_SET << PRINT_ERROR << ": INVALID SET" << std::endl;
         return 1; 
     }
 
@@ -77,7 +78,7 @@ int set_parse(std::string line)
     // if it exists, return an error
     if (set.count(name))
     {
-        std::cout << "[SET][WARN]: "<< name <<" already exists and is being overwritten" << std::endl;
+        std::cout << PRINT_SET << PRINT_WARN <<": "<< name <<" already exists and is being overwritten" << std::endl;
         set.erase(name);
     }
     // insert the new variable
@@ -96,12 +97,12 @@ void set_remove(int argc, char **argv)
         if (set.count(name))
         {
             set.erase(name);
-            std::cout << "[SET]: Removed " << name << std::endl;
+            std::cout << PRINT_SET << ": Removed " << name << std::endl;
         }
         else
         {
             // error if alias is not found
-            std::cout << "[SET][WARN]: " << name << " not found" << std::endl;
+            std::cerr << PRINT_SET << PRINT_ERROR << ": " << name << " not found" << std::endl;
         }
     }
 }
@@ -111,7 +112,7 @@ void set_print(void)
     // print out each set
     for (auto iter = set.begin(); iter != set.end(); iter++)
     {
-        std::cout << "[SET]: " << iter->first << "='" << iter->second << "'" << std::endl;
+        std::cout << PRINT_SET << ": " << iter->first << "='" << iter->second << "'" << std::endl;
     }
 }
 int builtin_set(int argc, char **argv)
@@ -131,31 +132,31 @@ int builtin_set(int argc, char **argv)
     {
         // delete all variables
         set.clear();
-        std::cout << "[SET]: All vars removed" << std::endl;
+        std::cout << PRINT_SET << ": All vars removed" << std::endl;
     }
     else if (argc >= 2 && strcmp(argv[1], "-v") == 0)
     {
         // delete all variables
         crash_debug = false;
-        std::cout << "[SET]: DEBUG mode disabled" << std::endl;
+        std::cout << PRINT_SET << ": DEBUG mode disabled" << std::endl;
     }
     else if (argc >= 2 && strcmp(argv[1], "+v") == 0)
     {
         // enable debug mode
         crash_debug = true;
-        std::cout << "[SET]: DEBUG mode enabled" << std::endl;
+        std::cout << PRINT_SET << ": DEBUG mode enabled" << std::endl;
     }
     else if (argc >= 2 && strcmp(argv[1], "-t") == 0)
     {
         // delete all variables
         crash_exit_on_err = false;
-        std::cout << "[SET]: FRAGILE mode disabled" << std::endl;
+        std::cout << PRINT_SET << ": FRAGILE mode disabled" << std::endl;
     }
     else if (argc >= 2 && strcmp(argv[1], "+t") == 0)
     {
         // delete all variables
         crash_exit_on_err = true;
-        std::cout << "[SET]: FRAGILE mode enabled" << std::endl;
+        std::cout << PRINT_SET << ": FRAGILE mode enabled" << std::endl;
     }
     else if (argc >= 3 && strcmp(argv[1], "-d") == 0)
     {

--- a/src/builtin/unalias.cc
+++ b/src/builtin/unalias.cc
@@ -1,4 +1,5 @@
 #include <crash.hh>
+#define PRINT_UNALIAS GREEN << "[UNALIAS]" << RESET
 
 int unalias_help(int argc, char **argv)
 {
@@ -23,7 +24,7 @@ int unalias_help(int argc, char **argv)
     }
     else
     {
-        std::cout << "[UNALIAS][ERROR]: Not a known command. Did you mean unalias -h or unalias -H ?" << std::endl; // not a known command
+        std::cerr << PRINT_UNALIAS << PRINT_ERROR << ": Not a known command. Did you mean unalias -h or unalias -H ?" << std::endl; // not a known command
         return 1;
     }
     return 0;
@@ -39,12 +40,12 @@ void unalias_parse(int argc, char **argv)
         if (aliases.count(name))
         {
             aliases.erase(name);
-            std::cout << "[UNALIAS]:Removed " << name << std::endl;
+            std::cout << PRINT_UNALIAS << ": Removed " << name << std::endl;
         }
         else
         {
             // error if alias is not found
-            std::cout << "[UNALIAS][ERROR]: " << name << " not found" << std::endl;
+            std::cerr << PRINT_UNALIAS << PRINT_ERROR << ": " << name << " not found" << std::endl;
         }
     }
     else
@@ -66,7 +67,7 @@ int builtin_unalias(int argc, char **argv)
     {
         // delete all aliases
         aliases.clear();
-        std::cout << "[UNALIAS]: All aliases removed" << std::endl;
+        std::cout << PRINT_UNALIAS << ": All aliases removed" << std::endl;
     }
     else
     {

--- a/src/main.cc
+++ b/src/main.cc
@@ -4,6 +4,7 @@
 #include <unistd.h>
 // include implementation
 #include <crash.hh>
+#define PRINT_MAIN GREEN << "[MAIN]" << RESET
 
 int main(int argc, char **argv)
 {
@@ -16,7 +17,7 @@ int main(int argc, char **argv)
         // make sure the file opened properly
         if (!content.is_open())
         {
-            std::cerr << "[MAIN][ERROR]: Failed to open file: " << argv[1] << std::endl;
+            std::cerr << PRINT_MAIN << PRINT_ERROR <<": Failed to open file: " << argv[1] << std::endl;
             return 1;
         }
 

--- a/src/shell.cc
+++ b/src/shell.cc
@@ -1,4 +1,5 @@
 #include <crash.hh>
+#define PRINT_SHELL GREEN << "[SHELL]" << RESET
 
 /********************************************************************/
 /*  State initialization                                            */
@@ -85,9 +86,9 @@ void print_prompt()
     getcwd(cwd, sizeof(cwd));
 
     if (crash_debug)
-        std::cout << "DEBUG_";
+        std::cout << CYAN << "DEBUG_" << RESET;
 
-    std::cout << "CRASH " << std::string(cwd) << " " << PROMPT_NEW;
+    std::cout << MAGENTA << "CRASH " << BLUE << std::string(cwd) << RESET << " " << PROMPT_NEW;
 }
 std::vector<std::string> wildCardMatch(std::string wildCard) // Match wildcard to file in current directory
 {
@@ -105,12 +106,12 @@ std::vector<std::string> wildCardMatch(std::string wildCard) // Match wildcard t
     }
     if (returnValue == GLOB_NOMATCH)
     {
-        std::cout << "[SHELL][ERROR]: No match found for wildcard: " << wildCard << std::endl;
+        std::cerr << PRINT_SHELL << PRINT_ERROR << ": No match found for wildcard: " << wildCard << std::endl;
         return result;
     }
     else
     {
-        std::cout << "[SHELL][ERROR]: Failed glob wildcard search: " << returnValue << std::endl;
+        std::cerr << PRINT_SHELL << PRINT_ERROR << ": Failed glob wildcard search: " << returnValue << std::endl;
         return result;
     }
 }
@@ -256,7 +257,7 @@ std::string get_from_path(std::string command)
     const char *env_p = std::getenv("PATH");
     if (!env_p)
     {
-        std::cout << "[SHELL][WARN]: Failed to get $PATH!\n";
+        std::cerr << PRINT_SHELL << PRINT_ERROR << ": Failed to get $PATH!\n";
         return {};
     }
 
@@ -314,13 +315,13 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
 
             if (crash_exit_on_err && error != 0)
             {
-                std::cout << "[SHELL][ERROR]: command failed." << std::endl;
+                std::cerr << PRINT_SHELL << PRINT_ERROR << ": command failed." << std::endl;
                 exit(error);
             }
         }
         else
         {
-            std::cout << "[SHELL][WARN]: Not yet implemented!\n";
+            std::cout << PRINT_SHELL << PRINT_WARN << ": Not yet implemented!\n";
         }
         // todo: free members of `argv`
     }
@@ -329,12 +330,12 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
         std::string full_path = get_from_path(tokens[0].data);
         if (crash_debug)
         {
-            std::cout << "[SHELL][DEBUG]: External Path: " << full_path << std::endl;
+            std::cout << PRINT_SHELL << PRINT_DEBUG <<": External Path: " << full_path << std::endl;
         }
 
         if (full_path.empty())
         {
-            std::cout << "[SHELL][ERROR]: Command not found: " << tokens[0].data << "\n";
+            std::cerr << PRINT_SHELL << PRINT_ERROR << ": Command not found: " << tokens[0].data << "\n";
             return;
         }
         // argv.erase(argv.begin()); This is bad!
@@ -373,7 +374,7 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
             argv.emplace_back(nullptr); // You might want this in a different spot? Maybe in argv_from_tokens? Idk?
             execv(full_path.c_str(), argv.data());
 
-            std::cerr << "[SHELL][ERROR]: Child process failure!\n";
+            std::cerr << PRINT_SHELL << PRINT_ERROR << ": Child process failure!\n";
             exit(130);
         }
         else
@@ -399,7 +400,7 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
     }
     else
     {
-        std::cout << "[ERROR]: Command was not of type \"Internal\" or \"External\"!\n";
+        std::cerr << PRINT_SHELL << PRINT_ERROR << ": Command was not of type \"Internal\" or \"External\"!\n";
     }
 }
 
@@ -512,7 +513,7 @@ void process(std::vector<Token> tokens)
         if (tokens[i].type == MetaChar)
         {
             if (redirect_type != NotMeta)
-                std::cout << "[WARN]: Multiple operators on one line are not supported!\n";
+                std::cout << PRINT_SHELL << PRINT_WARN <<": Multiple operators on one line are not supported!\n";
             else
             {
                 redirect_type = tokens[i].meta;
@@ -568,7 +569,7 @@ void process(std::vector<Token> tokens)
         int pipefd[2];
         if (pipe(pipefd) == -1)
         {
-            std::cerr << "[SHELL][ERROR]: Pipe error!" << std::endl;
+            std::cerr << PRINT_SHELL << PRINT_ERROR << ": Pipe error!" << std::endl;
             exit(1);
         }
         run_command(lhs, pipefd[1], -1, -1);
@@ -585,7 +586,7 @@ void process(std::vector<Token> tokens)
         }
         else
         {
-            std::cerr << "[SHELL][ERROR]: Redirect error! Failed to open " << filename << std::endl;
+            std::cerr << PRINT_SHELL << PRINT_ERROR << ": Redirect error! Failed to open " << filename << std::endl;
         }
 
         break;
@@ -730,7 +731,7 @@ void format_input(std::string line) // this used to be parse
     {
         for (size_t i = 0; i < tokens.size(); i++)
         {
-            std::cout << "[SHELL][DEBUG]: Token: " << i << " " << kwtype_as_string(tokens[i].type) << " Data: " << tokens[i].data << "\n";
+            std::cout << PRINT_SHELL << PRINT_DEBUG << ": Token: " << i << " " << kwtype_as_string(tokens[i].type) << " Data: " << tokens[i].data << "\n";
         }
     }
     // ONLY PROCESS IF TOKENS SIZE IS NOT ZERO. ELSE SEGFAULTS WILL OCCUR.

--- a/src/shell.cc
+++ b/src/shell.cc
@@ -84,7 +84,7 @@ void print_prompt()
     char cwd[PATH_MAX];
     getcwd(cwd, sizeof(cwd));
 
-    if(crash_debug)
+    if (crash_debug)
         std::cout << "DEBUG_";
 
     std::cout << "CRASH " << std::string(cwd) << " " << PROMPT_NEW;
@@ -312,12 +312,12 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
         {
             int error = tokens[0].function_pointer(argv.size(), argv.data());
 
-            if(crash_exit_on_err && error != 0)
+            if (crash_exit_on_err && error != 0)
             {
                 std::cout << "[SHELL][ERROR]: command failed." << std::endl;
                 exit(error);
             }
-        }   
+        }
         else
         {
             std::cout << "[SHELL][WARN]: Not yet implemented!\n";
@@ -327,16 +327,17 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
     else if (tokens[0].type == External)
     {
         std::string full_path = get_from_path(tokens[0].data);
-        if(crash_debug){
+        if (crash_debug)
+        {
             std::cout << "[SHELL][DEBUG]: External Path: " << full_path << std::endl;
         }
-        
+
         if (full_path.empty())
         {
             std::cout << "[SHELL][ERROR]: Command not found: " << tokens[0].data << "\n";
             return;
         }
-        //argv.erase(argv.begin()); This is bad!
+        // argv.erase(argv.begin()); This is bad!
 
         // create a child process
         pid_t child = fork();
@@ -369,7 +370,7 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
 
             // switch execution to new binary
 
-            argv.emplace_back(nullptr); //You might want this in a different spot? Maybe in argv_from_tokens? Idk?
+            argv.emplace_back(nullptr); // You might want this in a different spot? Maybe in argv_from_tokens? Idk?
             execv(full_path.c_str(), argv.data());
 
             std::cerr << "[SHELL][ERROR]: Child process failure!\n";
@@ -405,10 +406,10 @@ void run_command(std::vector<Token> tokens, int outfd, int errfd, int infd)
 std::vector<Token> lex(std::vector<std::string> inputLine)
 {
     // Check line for aliases, if so, replace
-    for(size_t i = 0; i < inputLine.size(); i++)
-    { //For every entry
-        if(aliases.find(inputLine[i]) != aliases.end())
-        { //We found an alias, so replace the entry with the alias
+    for (size_t i = 0; i < inputLine.size(); i++)
+    { // For every entry
+        if (aliases.find(inputLine[i]) != aliases.end())
+        { // We found an alias, so replace the entry with the alias
             inputLine.at(i) = aliases.at(inputLine[i]);
         }
     }
@@ -577,8 +578,16 @@ void process(std::vector<Token> tokens)
         break;
     case Redirect:
         fd = fopen(filename.c_str(), &open_mode);
-        run_command(lhs, -1, -1, fileno(fd));
-        fclose(fd);
+        if (fd != nullptr)
+        {
+            run_command(lhs, -1, -1, fileno(fd));
+            fclose(fd);
+        }
+        else
+        {
+            std::cerr << "[SHELL][ERROR]: Redirect error! Failed to open " << filename << std::endl;
+        }
+
         break;
     }
 
@@ -717,7 +726,8 @@ void format_input(std::string line) // this used to be parse
     // not a continuation, as we would've returned
 
     std::vector<Token> tokens = lex(split_line(current_line));
-    if(crash_debug){
+    if (crash_debug)
+    {
         for (size_t i = 0; i < tokens.size(); i++)
         {
             std::cout << "[SHELL][DEBUG]: Token: " << i << " " << kwtype_as_string(tokens[i].type) << " Data: " << tokens[i].data << "\n";


### PR DESCRIPTION
Adds a standard system for ERROR, WARN, and DEBUG text in the header
Then uses this along with the file name in each print

Additionally switched some `cout`s to `cerr`s

Closes #117 